### PR TITLE
Resolve compile issues with the Conduit interface

### DIFF
--- a/rest/rest.ml
+++ b/rest/rest.ml
@@ -7,9 +7,8 @@ open Binance
 
 let url = Uri.make ~scheme:"https" ~host:"api.binance.com" ()
 let ssl_config =
-  Conduit_async_ssl.Cfg.create
+  Conduit_async_ssl.Ssl_config.configure
     ~name:"Binance REST"
-    ~hostname:"api.binance.com"
     ()
 
 module BinanceError = struct

--- a/ws/ws.ml
+++ b/ws/ws.ml
@@ -69,7 +69,7 @@ let event_encoding =
        (req "data" event_encoding))
 
 let ssl_config =
-  Conduit_async_ssl.Cfg.create ~name:"Binance WS" ()
+  Conduit_async_ssl.Ssl_config.configure ~name:"Binance WS" ()
 
 let open_connection ?(buf=Bi_outbuf.create 4096) ?connected ?log streams =
   let uri = Uri.with_path uri "stream" in
@@ -89,7 +89,7 @@ let open_connection ?(buf=Bi_outbuf.create 4096) ?connected ?log streams =
         Log.info log "[WS] connecting to %s" uri_str);
     Socket.(setopt s Opt.nodelay true);
     (if scheme = "https" || scheme = "wss" then
-       Conduit_async_ssl.(ssl_connect ~cfg:ssl_config r w)
+       Conduit_async_ssl.ssl_connect ssl_config r w
      else return (r, w)) >>= fun (ssl_r, ssl_w) ->
     let ws_r, ws_w =
       Websocket_async.client_ez ?log


### PR DESCRIPTION
On my device running:

> Ocaml 4.06.1
> conduit 1.1.0
> websocket-async 2.11

This project does not build complaining of:

> Unbound module Conduit_async_ssl.Cfg

In rest/rest.ml & ws/ws.ml

This patch updates those lines to what I think (I'm new to this stack) is the current conduit library interface for creating SSL configurations.

I verified that the test/depth.ml tool works find after applying this change. 